### PR TITLE
Change dependency name from api-clients to api and upgrade to latest version 0.33.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module code.vegaprotocol.io/vegatools
 go 1.16
 
 require (
-	github.com/ethereum/go-ethereum v1.9.25 // indirect
-	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/ethereum/go-ethereum v1.9.25
+	github.com/golang/protobuf v1.4.2
 	github.com/mwitkow/go-proto-validators v0.3.2 // indirect
-	github.com/spf13/cobra v1.1.3 // indirect
-	github.com/vegaprotocol/api-clients v0.31.0 // indirect
-	google.golang.org/grpc v1.35.0 // indirect
+	github.com/spf13/cobra v1.1.3
+	github.com/vegaprotocol/api v0.33.0
+	google.golang.org/grpc v1.35.0
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKk
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/vegaprotocol/api-clients v0.31.0 h1:UHPi2g6umORKEBCxyCkhLGDUBMkpEFU3/qnc7HiO4S8=
-github.com/vegaprotocol/api-clients v0.31.0/go.mod h1:FSy8HG+7TserVjTdvxUgmSEH9tEqwbVr0y30VyA+H1c=
+github.com/vegaprotocol/api v0.33.0 h1:IVBtmSJu5DXJlWayrjkaJgdpVy8OvCq+vlDAwdXwln0=
+github.com/vegaprotocol/api v0.33.0/go.mod h1:T130O/Ui1oMsVc21QtxbtOrYtgD4G7BLigVY2h/BaIM=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 
 	"github.com/golang/protobuf/jsonpb"
-	"github.com/vegaprotocol/api-clients/go/generated/code.vegaprotocol.io/vega/proto"
-	"github.com/vegaprotocol/api-clients/go/generated/code.vegaprotocol.io/vega/proto/api"
+	"github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto"
+	"github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto/api"
 	"google.golang.org/grpc"
 )
 


### PR DESCRIPTION
This PR closes #1.
Changes dependency name from `api-clients` to `api`, and its version from `0.31.0` to `0.33.0`.