### PR TITLE
Add log format option

### DIFF
--- a/cmd/stream.go
+++ b/cmd/stream.go
@@ -12,7 +12,7 @@ var (
 		party      string
 		market     string
 		serverAddr string
-		logFormat  bool
+		logFormat  string
 	}
 
 	streamCmd = &cobra.Command{
@@ -28,7 +28,7 @@ func init() {
 	streamCmd.Flags().StringVarP(&streamOpts.party, "party", "p", "", "name of the party to listen for updates")
 	streamCmd.Flags().StringVarP(&streamOpts.market, "market", "m", "", "name of the market to listen for updates")
 	streamCmd.Flags().StringVarP(&streamOpts.serverAddr, "address", "a", "", "address of the grpc server")
-	streamCmd.Flags().BoolVar(&streamOpts.logFormat, "log-format", false, "output stream data in log format")
+	streamCmd.Flags().StringVar(&streamOpts.logFormat, "log-format", "raw", "output stream data in specified format. Allowed values: raw (default), text, json")
 	streamCmd.MarkFlagRequired("address")
 }
 

--- a/cmd/stream.go
+++ b/cmd/stream.go
@@ -12,6 +12,7 @@ var (
 		party      string
 		market     string
 		serverAddr string
+		logFormat  bool
 	}
 
 	streamCmd = &cobra.Command{
@@ -27,9 +28,10 @@ func init() {
 	streamCmd.Flags().StringVarP(&streamOpts.party, "party", "p", "", "name of the party to listen for updates")
 	streamCmd.Flags().StringVarP(&streamOpts.market, "market", "m", "", "name of the market to listen for updates")
 	streamCmd.Flags().StringVarP(&streamOpts.serverAddr, "address", "a", "", "address of the grpc server")
+	streamCmd.Flags().BoolVar(&streamOpts.logFormat, "log-format", false, "output stream data in log format")
 	streamCmd.MarkFlagRequired("address")
 }
 
 func runStream(cmd *cobra.Command, args []string) error {
-	return stream.Run(streamOpts.batchSize, streamOpts.party, streamOpts.market, streamOpts.serverAddr)
+	return stream.Run(streamOpts.batchSize, streamOpts.party, streamOpts.market, streamOpts.serverAddr, streamOpts.logFormat)
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto"
@@ -75,9 +76,8 @@ func run(
 				if err != nil {
 					log.Printf("unable to marshal event err=%v", err)
 				}
-
 				if logFormat {
-					log.Printf("%v\n", estr)
+					fmt.Printf("{\"time\":\"%v\",%v\n", time.Now().UTC().Format(time.RFC3339Nano), estr[1:])
 				} else {
 					fmt.Printf("%v\n", estr)
 				}
@@ -101,7 +101,6 @@ func Run(
 	party, market, serverAddr string,
 	logFormat bool,
 ) error {
-	log.SetFlags(log.LUTC | log.Ldate | log.Lmicroseconds)
 	flag.Parse()
 
 	if len(serverAddr) <= 0 {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -23,6 +23,7 @@ func run(
 	wg *sync.WaitGroup,
 	batchSize uint,
 	party, market, serverAddr string,
+	logFormat bool,
 ) error {
 	conn, err := grpc.Dial(serverAddr, grpc.WithInsecure())
 	if err != nil {
@@ -75,7 +76,11 @@ func run(
 					log.Printf("unable to marshal event err=%v", err)
 				}
 
-				fmt.Printf("%v\n", estr)
+				if logFormat {
+					log.Printf("%v\n", estr)
+				} else {
+					fmt.Printf("%v\n", estr)
+				}
 			}
 			if batchSize > 0 {
 				if err := stream.SendMsg(poll); err != nil {
@@ -94,7 +99,9 @@ func run(
 func Run(
 	batchSize uint,
 	party, market, serverAddr string,
+	logFormat bool,
 ) error {
+	log.SetFlags(log.LUTC | log.Ldate | log.Lmicroseconds)
 	flag.Parse()
 
 	if len(serverAddr) <= 0 {
@@ -104,7 +111,7 @@ func Run(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	wg := sync.WaitGroup{}
-	if err := run(ctx, cancel, &wg, batchSize, party, market, serverAddr); err != nil {
+	if err := run(ctx, cancel, &wg, batchSize, party, market, serverAddr, logFormat); err != nil {
 		return fmt.Errorf("error when starting the stream: %v", err)
 	}
 


### PR DESCRIPTION
Add log format option that adds `time` field to JSON representation of BusEvent.
Connected to vegaprotocol/devops-infra#457

Goal: We are using Fluentd to upload logs to GCP console and make them queryable there.
Constraints:
- Bus events are multi-level JSON messages, and we don't want to change it,
- We want to have our event timestamp, to workaround possible Fluentd/GCP delays/problems,
Solution: Fluentd has a built-in JSON format, that also supports event timestamps. It requires every line to be a single JSON, it does not support mixed lines: part of it JSON, part of it standard log format. In this format, the timestamp is a `time` field inside JSON.