### PR TITLE
Add market stake viewer (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+unsafe_withdraw_keystore

--- a/cmd/marketstakeviewer.go
+++ b/cmd/marketstakeviewer.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"code.vegaprotocol.io/vegatools/marketstakeviewer"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	marketStakeViewerOpts struct {
+		serverAddr string
+	}
+
+	marketStakeViewerCmd = &cobra.Command{
+		Use:   "marketstakeviewer",
+		Short: "Display market stake info for all markets",
+		RunE:  runMarketStakeViewer,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(marketStakeViewerCmd)
+	marketStakeViewerCmd.Flags().StringVarP(&marketStakeViewerOpts.serverAddr, "address", "a", "", "address of the grpc server (host:port)")
+	marketStakeViewerCmd.MarkFlagRequired("address")
+}
+
+func runMarketStakeViewer(cmd *cobra.Command, args []string) error {
+	return marketstakeviewer.Run(marketStakeViewerOpts.serverAddr)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1
 	github.com/vegaprotocol/api v0.33.0
+	golang.org/x/lint v0.0.0-20190930215403-16217165b5de // indirect
 	google.golang.org/grpc v1.35.0
 )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,5 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1
 	github.com/vegaprotocol/api v0.33.0
-	github.com/vegaprotocol/api-clients v0.33.0
-	golang.org/x/lint v0.0.0-20190930215403-16217165b5de // indirect
 	google.golang.org/grpc v1.35.0
 )

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,7 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -415,6 +416,7 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69 h1:yBHHx+XZqXJBm6Exke3N7V9gnlsyXxoCPEb1yVenjfk=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6 h1:Eey/GGQ/E5Xp1P2Lyx1qj007hLZfbi0+CoVeJruGCtI=
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6/go.mod h1:Dmm/EzmjnCiweXmzRIAiUWCInVmPgjkzgv5k4tVyXiQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -123,6 +124,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -182,8 +184,10 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
@@ -292,8 +296,6 @@ github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:s
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vegaprotocol/api v0.33.0 h1:IVBtmSJu5DXJlWayrjkaJgdpVy8OvCq+vlDAwdXwln0=
 github.com/vegaprotocol/api v0.33.0/go.mod h1:T130O/Ui1oMsVc21QtxbtOrYtgD4G7BLigVY2h/BaIM=
-github.com/vegaprotocol/api-clients v0.33.0 h1:wmiXzQvs9bWJFkElI31UIO0W0dOhhAf4C/LaCuyiFo0=
-github.com/vegaprotocol/api-clients v0.33.0/go.mod h1:FSy8HG+7TserVjTdvxUgmSEH9tEqwbVr0y30VyA+H1c=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -325,7 +327,6 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -414,11 +415,11 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69 h1:yBHHx+XZqXJBm6Exke3N7V9gnlsyXxoCPEb1yVenjfk=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -460,6 +461,7 @@ google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/marketstakeviewer/marketstakeviewer.go
+++ b/marketstakeviewer/marketstakeviewer.go
@@ -1,0 +1,244 @@
+package marketstakeviewer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto"
+	"github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto/api"
+
+	"github.com/gdamore/tcell/v2"
+	"google.golang.org/grpc"
+)
+
+var (
+	ts          tcell.Screen
+	redStyle    tcell.Style
+	greenStyle  tcell.Style
+	yellowStyle tcell.Style
+	whiteStyle  tcell.Style
+
+	args struct {
+		gRPCAddress string
+	}
+)
+
+func initialiseScreen() error {
+	var e error
+	ts, e = tcell.NewScreen()
+	if e != nil {
+		log.Fatalln("Failed to create new tcell screen", e)
+		return e
+	}
+
+	e = ts.Init()
+	if e != nil {
+		log.Fatalln("Failed to initialise the tcell screen", e)
+		return e
+	}
+
+	whiteStyle = tcell.StyleDefault.
+		Background(tcell.ColorReset).
+		Foreground(tcell.ColorWhite)
+	greenStyle = tcell.StyleDefault.
+		Background(tcell.ColorReset).
+		Foreground(tcell.ColorGreen)
+	yellowStyle = tcell.StyleDefault.
+		Background(tcell.ColorReset).
+		Foreground(tcell.ColorYellow)
+	redStyle = tcell.StyleDefault.
+		Background(tcell.ColorReset).
+		Foreground(tcell.ColorRed)
+
+	return nil
+}
+
+func drawLeftString(x, y, maxw int, style tcell.Style, str string) {
+	for i, c := range str {
+		if i >= maxw {
+			break
+		}
+		ts.SetContent(x+i, y, c, nil, style)
+	}
+}
+
+func drawTime() {
+	now := time.Now()
+	w, _ := ts.Size()
+	text := fmt.Sprintf("%02d:%02d:%02d", now.Hour(), now.Minute(), now.Second())
+	drawLeftString(w-8, 0, 8, whiteStyle, text)
+}
+
+func drawRightString(x, y, w int, style tcell.Style, text string) {
+	if len(text) > w {
+		text = text[:w]
+	}
+	drawLeftString(x+w-len(text), y, w, style, text)
+}
+
+func drawRightInt64(x, y, w int, style tcell.Style, n int64) {
+	f := fmt.Sprintf("%%%dd", w)
+	text := fmt.Sprintf(f, n)
+	drawLeftString(x, y, w, style, text)
+}
+
+func drawRightUInt64(x, y, w int, style tcell.Style, n uint64) {
+	f := fmt.Sprintf("%%%dd", w)
+	text := fmt.Sprintf(f, n)
+	drawLeftString(x, y, w, style, text)
+}
+
+func drawRightFloat64(x, y, w int, style tcell.Style, n float64) {
+	f := fmt.Sprintf("%%%d.2f", w)
+	text := fmt.Sprintf(f, n)
+	drawLeftString(x, y, w, style, text)
+}
+
+func drawRightPercent(x, y, w int, style tcell.Style, n float64) {
+	f := fmt.Sprintf("%%%d.2f%%%%", w-1)
+	text := fmt.Sprintf(f, n)
+	drawLeftString(x, y, w, style, text)
+}
+
+func drawHeaders(triggerRatio float64) {
+	drawLeftString(0, 0, 999, whiteStyle, fmt.Sprintf("============== Stake (trigger at %5.2f%%) =================", triggerRatio))
+	drawRightString(0, 1, 15, whiteStyle, "Supplied")
+	drawRightString(16, 1, 15, whiteStyle, "Target")
+	drawRightString(32, 1, 15, whiteStyle, "Surplus")
+	drawRightString(48, 1, 10, whiteStyle, "Percent")
+	drawLeftString(59, 1, 18, whiteStyle, "Trading Mode")
+	drawLeftString(78, 1, 11, whiteStyle, "Trigger")
+	drawLeftString(90, 1, 64, whiteStyle, "Market ID")
+}
+
+func processMarketsStake(stream api.TradingDataService_ObserveEventBusClient, triggerRatio float64) {
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			log.Println("stream closed by server: ", err)
+			break
+		}
+		if err != nil {
+			log.Println("stream closed: ", err)
+			break
+		}
+
+		// w, h := ts.Size()
+
+		ts.Clear()
+		drawHeaders(triggerRatio * 100.0)
+		drawTime()
+
+		for i, evt := range resp.Events {
+			md := evt.GetMarketData()
+			if md == nil {
+				// somehow this is not a MarketData event
+				continue
+			}
+			supplied, err := strconv.ParseUint(md.SuppliedStake, 10, 64)
+			if err != nil {
+				drawLeftString(0, i+2, 999, whiteStyle, err.Error())
+				continue
+			}
+			target, err := strconv.ParseUint(md.TargetStake, 10, 64)
+			if err != nil {
+				drawLeftString(0, i+2, 999, whiteStyle, err.Error())
+				continue
+			}
+			surplus := int64(supplied) - int64(target)
+			drawRightUInt64(0, i+2, 15, whiteStyle, supplied)
+			drawRightUInt64(16, i+2, 15, whiteStyle, target)
+			var s tcell.Style
+			ratio := float64(supplied) / float64(target)
+			if ratio >= 1.0 {
+				s = greenStyle
+			} else if ratio >= triggerRatio {
+				s = yellowStyle
+			} else {
+				s = redStyle
+			}
+			drawRightInt64(32, i+2, 15, s, surplus)
+			drawRightPercent(48, i+2, 10, s, ratio*100.0)
+			drawLeftString(59, i+2, 18, whiteStyle, fmt.Sprintf("%s", md.MarketTradingMode)[13:])
+			drawLeftString(78, i+2, 11, whiteStyle, fmt.Sprintf("%s", md.Trigger)[16:])
+			drawLeftString(90, i+2, 64, whiteStyle, md.Market)
+		}
+		ts.Show()
+	}
+}
+
+func getTargetStakeTriggeringRatio(dataclient api.TradingDataServiceClient) (ratio float64, err error) {
+	const key = "market.liquidity.targetstake.triggering.ratio"
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var response *api.NetworkParametersResponse
+	response, err = dataclient.NetworkParameters(ctx, &api.NetworkParametersRequest{})
+	if err != nil {
+		err = fmt.Errorf("gRPC NetworkParameters call failed: %w", err)
+		return
+	}
+	for _, p := range response.NetworkParameters {
+		if p.Key != key {
+			continue
+		}
+		ratio, err = strconv.ParseFloat(p.Value, 64)
+		if err != nil {
+			err = fmt.Errorf("failed to parse float: %w", err)
+		}
+		return
+	}
+	err = fmt.Errorf("failed to find network parameter: %s", key)
+	return
+}
+
+// Run is the main entry point for this tool
+func Run(gRPCAddress string) error {
+	// Create connection to vega
+	connection, err := grpc.Dial(gRPCAddress, grpc.WithInsecure())
+	if err != nil {
+		return fmt.Errorf("Failed to connect to the vega gRPC port: %w", err)
+	}
+	defer connection.Close()
+	dataclient := api.NewTradingDataServiceClient(connection)
+
+	triggerRatio, err := getTargetStakeTriggeringRatio(dataclient)
+	if err != nil {
+		return fmt.Errorf("Failed to get target stake triggering ratio: %w", err)
+	}
+
+	observerEvent := api.ObserveEventBusRequest{
+		Type: []proto.BusEventType{proto.BusEventType_BUS_EVENT_TYPE_MARKET_DATA},
+	}
+	eventStream, err := dataclient.ObserveEventBus(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to connect to the event bus: %w", err)
+	}
+	eventStream.Send(&observerEvent)
+	eventStream.CloseSend()
+
+	initialiseScreen()
+	ts.Clear()
+	drawHeaders(triggerRatio * 100.0)
+	drawTime()
+	ts.Show()
+
+	go processMarketsStake(eventStream, triggerRatio)
+
+	for {
+		switch ev := ts.PollEvent().(type) {
+		case *tcell.EventResize:
+			ts.Sync()
+		case *tcell.EventKey:
+			if ev.Key() == tcell.KeyEscape ||
+				ev.Rune() == 'q' {
+				ts.Fini()
+				os.Exit(0)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a market stake viewer.

```bash
make build
./build/vegatools marketstakeviewer --address n06.testnet.vega.xyz:3002
```

![marketstakeviewer](https://user-images.githubusercontent.com/48948661/114523775-83e92e80-9c3c-11eb-89ea-b404bb989484.png)

Closes #8.