### PR TITLE
Add reconnecting code and command line option

### DIFF
--- a/cmd/stream.go
+++ b/cmd/stream.go
@@ -13,6 +13,7 @@ var (
 		market     string
 		serverAddr string
 		logFormat  string
+		reconnect  bool
 	}
 
 	streamCmd = &cobra.Command{
@@ -29,9 +30,15 @@ func init() {
 	streamCmd.Flags().StringVarP(&streamOpts.market, "market", "m", "", "name of the market to listen for updates")
 	streamCmd.Flags().StringVarP(&streamOpts.serverAddr, "address", "a", "", "address of the grpc server")
 	streamCmd.Flags().StringVar(&streamOpts.logFormat, "log-format", "raw", "output stream data in specified format. Allowed values: raw (default), text, json")
+	streamCmd.Flags().BoolVarP(&streamOpts.reconnect, "reconnect", "r", false, "if connection dies, attempt to reconnect")
 	streamCmd.MarkFlagRequired("address")
 }
 
 func runStream(cmd *cobra.Command, args []string) error {
-	return stream.Run(streamOpts.batchSize, streamOpts.party, streamOpts.market, streamOpts.serverAddr, streamOpts.logFormat)
+	return stream.Run(streamOpts.batchSize,
+		streamOpts.party,
+		streamOpts.market,
+		streamOpts.serverAddr,
+		streamOpts.logFormat,
+		streamOpts.reconnect)
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -101,9 +101,17 @@ func run(
 			if reconnect {
 				// Keep waiting and retrying until we reconnect
 				for true {
-					time.Sleep(time.Second * 5)
-					log.Printf("Attempting to reconnect to the node")
-					conn, stream, err = connect(ctx, batchSize, party, market, serverAddr)
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						time.Sleep(time.Second * 5)
+						log.Printf("Attempting to reconnect to the node")
+						conn, stream, err = connect(ctx, batchSize, party, market, serverAddr)
+						if err == nil {
+							break
+						}
+					}
 					if err == nil {
 						break
 					}


### PR DESCRIPTION
If the users specifies the `-r` option in the `steam` tool it will cause the client to attempt to reconnect every 5 seconds until it succeeds. This will prevent the need to rerun the app after a disconnect.

Closes #12 