### PR TITLE
Add types flag to make life easier for QA

### DIFF
--- a/cmd/stream.go
+++ b/cmd/stream.go
@@ -14,6 +14,7 @@ var (
 		serverAddr string
 		logFormat  string
 		reconnect  bool
+		types      []string
 	}
 
 	streamCmd = &cobra.Command{
@@ -31,6 +32,7 @@ func init() {
 	streamCmd.Flags().StringVarP(&streamOpts.serverAddr, "address", "a", "", "address of the grpc server")
 	streamCmd.Flags().StringVar(&streamOpts.logFormat, "log-format", "raw", "output stream data in specified format. Allowed values: raw (default), text, json")
 	streamCmd.Flags().BoolVarP(&streamOpts.reconnect, "reconnect", "r", false, "if connection dies, attempt to reconnect")
+	streamCmd.Flags().StringSliceVarp(&streamOpts.types, "type", "t", "", "one or more event types to subscribe to (default=ALL)")
 	streamCmd.MarkFlagRequired("address")
 }
 
@@ -40,5 +42,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 		streamOpts.market,
 		streamOpts.serverAddr,
 		streamOpts.logFormat,
-		streamOpts.reconnect)
+		streamOpts.reconnect,
+		streamOpts.types,
+	)
 }

--- a/cmd/stream.go
+++ b/cmd/stream.go
@@ -32,7 +32,7 @@ func init() {
 	streamCmd.Flags().StringVarP(&streamOpts.serverAddr, "address", "a", "", "address of the grpc server")
 	streamCmd.Flags().StringVar(&streamOpts.logFormat, "log-format", "raw", "output stream data in specified format. Allowed values: raw (default), text, json")
 	streamCmd.Flags().BoolVarP(&streamOpts.reconnect, "reconnect", "r", false, "if connection dies, attempt to reconnect")
-	streamCmd.Flags().StringSliceVarP(&streamOpts.types, "type", "t", "", "one or more event types to subscribe to (default=ALL)")
+	streamCmd.Flags().StringSliceVarP(&streamOpts.types, "type", "t", nil, "one or more event types to subscribe to (default=ALL)")
 	streamCmd.MarkFlagRequired("address")
 }
 

--- a/cmd/stream.go
+++ b/cmd/stream.go
@@ -32,7 +32,7 @@ func init() {
 	streamCmd.Flags().StringVarP(&streamOpts.serverAddr, "address", "a", "", "address of the grpc server")
 	streamCmd.Flags().StringVar(&streamOpts.logFormat, "log-format", "raw", "output stream data in specified format. Allowed values: raw (default), text, json")
 	streamCmd.Flags().BoolVarP(&streamOpts.reconnect, "reconnect", "r", false, "if connection dies, attempt to reconnect")
-	streamCmd.Flags().StringSliceVarp(&streamOpts.types, "type", "t", "", "one or more event types to subscribe to (default=ALL)")
+	streamCmd.Flags().StringSliceVarP(&streamOpts.types, "type", "t", "", "one or more event types to subscribe to (default=ALL)")
 	streamCmd.MarkFlagRequired("address")
 }
 


### PR DESCRIPTION
Option to specify one or more event types to subscribe to. The flag is `StringSlice`. It can take event type names (`BUS_EVENT_TYPE_ALL`), or their numeric values (`1`). First, the command will attempt to parse values as integers, to find the name (string) value. The string is then used to add the type constant to the request.