### PR TITLE
Use TradingService in vegatools stream

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	api "code.vegaprotocol.io/protos/data-node/api/v1"
+	api "code.vegaprotocol.io/protos/vega/api"
 	eventspb "code.vegaprotocol.io/protos/vega/events/v1"
 	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/grpc"
@@ -21,13 +21,13 @@ import (
 
 func connect(ctx context.Context,
 	batchSize uint,
-	party, market, serverAddr string, types []string) (*grpc.ClientConn, api.TradingDataService_ObserveEventBusClient, error) {
+	party, market, serverAddr string, types []string) (*grpc.ClientConn, api.TradingService_ObserveEventBusClient, error) {
 	conn, err := grpc.Dial(serverAddr, grpc.WithInsecure())
 	if err != nil {
 		return nil, nil, err
 	}
 
-	client := api.NewTradingDataServiceClient(conn)
+	client := api.NewTradingServiceClient(conn)
 	stream, err := client.ObserveEventBus(ctx)
 	if err != nil {
 		conn.Close()


### PR DESCRIPTION
Now the core and data-node both implement TradingService, this will allow the vegatools stream to connet transparently to either of them.