### PR TITLE
output from vegatools snapshotdb is not valid JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### 🐛 Fixes
 - [78](https://github.com/vegaprotocol/vegatools/pull/78) - Fix build with missing dependency
+- [91](https://github.com/vegaprotocol/vegatools/pull/91) - Output of `snapshotdb` is now valid json
 
 ## 0.41.1
 *2021-08-31*

--- a/snapshotdb/snapshotdb.go
+++ b/snapshotdb/snapshotdb.go
@@ -1,12 +1,60 @@
 package snapshotdb
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/cosmos/iavl"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	db "github.com/tendermint/tm-db"
 )
+
+type SnapshotData struct {
+	Version int64 `json:"version"`
+	Height  int64 `json:"height"`
+	Size    int64 `json:"size"`
+}
+
+func displaySnapshotData(tree *iavl.MutableTree, versions []int) error {
+	j := struct {
+		Snapshots []SnapshotData `json:"snapshots"`
+	}{}
+
+	for _, version := range versions {
+
+		v, err := tree.LazyLoadVersion(int64(version))
+		if err != nil {
+			return err
+		}
+		j.Snapshots = append(j.Snapshots, SnapshotData{
+			Version: v,
+			Height:  int64(tree.Height()),
+			Size:    tree.Size(),
+		})
+	}
+
+	b, err := json.Marshal(j)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+func displayNumberOfVersions(versions int) error {
+	j := struct {
+		Versions int64 `json:"n_versions"`
+	}{
+		Versions: int64(versions),
+	}
+
+	b, err := json.Marshal(j)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+	return nil
+}
 
 // Run is the main entry point for this tool
 func Run(dbpath string, versionsOnly bool) error {
@@ -21,22 +69,17 @@ func Run(dbpath string, versionsOnly bool) error {
 	}
 
 	tree, err := iavl.NewMutableTree(db, 0)
-	_, err = tree.Load()
+	if err != nil {
+		return err
+	}
+
+	if _, err := tree.Load(); err != nil {
+		return err
+	}
 	versions := tree.AvailableVersions()
 
 	if versionsOnly {
-		// Only output a json version of the number of snapshot versions that are in this database
-		fmt.Printf("{ Versions: %d }\n", len(versions))
-	} else {
-		// Run through all the snapshots and display some details
-		fmt.Printf("{ Snapshots: {\n")
-		for _, version := range versions {
-			v, err := tree.LazyLoadVersion(int64(version))
-			if err == nil {
-				fmt.Printf("  { Version: %d, Height: %d, Size: %d },\n", v, tree.Height(), tree.Size())
-			}
-		}
-		fmt.Printf(" }\n}\n")
+		return displayNumberOfVersions(len(versions))
 	}
-	return nil
+	return displaySnapshotData(tree, versions)
 }

--- a/snapshotdb/snapshotdb.go
+++ b/snapshotdb/snapshotdb.go
@@ -9,6 +9,7 @@ import (
 	db "github.com/tendermint/tm-db"
 )
 
+// SnapshotData is a representation of the information we an scrape from the avl tree
 type SnapshotData struct {
 	Version int64 `json:"version"`
 	Height  int64 `json:"height"`


### PR DESCRIPTION
closes #91 
New output:
```
{
  "snapshots": [
    {
      "version": 1,
      "height": 6,
      "size": 32
    }
  ]
}
```