### PR TITLE
feat: choose snapshot to print as JSON by block-height and not tree version

### DIFF
--- a/cmd/snapshotdb.go
+++ b/cmd/snapshotdb.go
@@ -9,7 +9,7 @@ var (
 	snapshotDBOpts struct {
 		databasePath     string
 		outputPath       string
-		versionToOutput  int64
+		heightToOutput   int64
 		versionCountOnly bool
 	}
 
@@ -24,11 +24,11 @@ func init() {
 	rootCmd.AddCommand(snapshotDBCmd)
 	snapshotDBCmd.Flags().StringVarP(&snapshotDBOpts.databasePath, "db-path", "d", "", "path to the goleveldb database folder")
 	snapshotDBCmd.Flags().StringVarP(&snapshotDBOpts.outputPath, "out", "o", "", "file to write JSON to")
-	snapshotDBCmd.Flags().Int64VarP(&snapshotDBOpts.versionToOutput, "version-out", "r", 0, "version of the tree to dump into JSON")
+	snapshotDBCmd.Flags().Int64VarP(&snapshotDBOpts.heightToOutput, "block-height", "r", 0, "block-height of the snapshot to dump")
 	snapshotDBCmd.Flags().BoolVarP(&snapshotDBOpts.versionCountOnly, "versions", "v", false, "display the number of stored versions")
 	snapshotDBCmd.MarkFlagRequired("db-path")
 }
 
 func runSnapshotDBCmd(cmd *cobra.Command, args []string) error {
-	return snapshotdb.Run(snapshotDBOpts.databasePath, snapshotDBOpts.versionCountOnly, snapshotDBOpts.outputPath, snapshotDBOpts.versionToOutput)
+	return snapshotdb.Run(snapshotDBOpts.databasePath, snapshotDBOpts.versionCountOnly, snapshotDBOpts.outputPath, snapshotDBOpts.heightToOutput)
 }


### PR DESCRIPTION
and if you don't pass in a block-height it'll write to file the JSON for the latest snapshot.