### PR TITLE
Adding support for multiple markets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [190](https://github.com/vegaprotocol/vegatools/issue/190) - Removed validation time from market proposal
 - [197](https://github.com/vegaprotocol/vegatools/issue/197) - Update protos location to their new place inside Vega
 - [206](https://github.com/vegaprotocol/vegatools/issue/206) - Move liquidity provision from inside market proposal to it's own proposal
+- [208](https://github.com/vegaprotocol/vegatools/issue/208) - User selectable number of markets for load testing 
 
 ### 🐛 Fixes
 - [78](https://github.com/vegaprotocol/vegatools/pull/78) - Fix build with missing dependency

--- a/cmd/perftest.go
+++ b/cmd/perftest.go
@@ -24,6 +24,7 @@ func init() {
 	perfTestCmd.Flags().IntVarP(&opts.CommandsPerSecond, "cps", "c", 100, "commands per second")
 	perfTestCmd.Flags().IntVarP(&opts.RuntimeSeconds, "runtime", "r", 60, "runtime in seconds")
 	perfTestCmd.Flags().IntVarP(&opts.UserCount, "users", "u", 10, "number of users to send commands with")
+	perfTestCmd.Flags().IntVarP(&opts.MarketCount, "markets", "m", 1, "number of markets to create and use")
 	perfTestCmd.MarkFlagRequired("address")
 	perfTestCmd.MarkFlagRequired("wallet")
 	perfTestCmd.MarkFlagRequired("faucet")

--- a/perftest/perftest.go
+++ b/perftest/perftest.go
@@ -23,6 +23,7 @@ type Opts struct {
 	CommandsPerSecond int
 	RuntimeSeconds    int
 	UserCount         int
+	MarketCount       int
 }
 
 type perfLoadTesting struct {
@@ -297,7 +298,7 @@ func Run(opts Opts) error {
 
 	// Send in a proposal to create a new market and vote to get it through
 	fmt.Print("Proposing and voting in new market...")
-	marketIDs, err := plt.proposeAndEnactMarket(1)
+	marketIDs, err := plt.proposeAndEnactMarket(opts.MarketCount)
 	if err != nil {
 		fmt.Println("FAILED")
 		return err


### PR DESCRIPTION
Allow the user to specify the number of markets we use for load testing

Closes #208 