### PR TITLE
Added block time reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - [208](https://github.com/vegaprotocol/vegatools/issue/208) - User selectable number of markets for load testing 
 - [210](https://github.com/vegaprotocol/vegatools/issue/210) - Added delta based market depth display 
 - [214](https://github.com/vegaprotocol/vegatools/issue/214) - Increase gRPC receive buffer size 
+- [216](https://github.com/vegaprotocol/vegatools/issue/216) - Display block time in eventrate tool to monitor event stream lag 
 
 ### 🐛 Fixes
 - [78](https://github.com/vegaprotocol/vegatools/pull/78) - Fix build with missing dependency


### PR DESCRIPTION
Print out the block time as reported in the latest EVENT_TIME_UPDATE event we receive.
Use this to monitor for event stream lag.

Closes #216 
