### PR TITLE
feat: stop running multiple workflows

### DIFF
--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -4,7 +4,7 @@
 name: 'Project Board Automation'
 
 "on":
-    pull_request_target:
+  pull_request_target:
     branches: [develop, main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request:
@@ -29,6 +29,10 @@ env:
   MERGED_COLUMN_NAME: '"Merged"'
   DONE_COLUMN_NAME: '"Done"'
   ITERATION_FIELD_NAME: 'Sprint'   # See project settings (default is `Iteration`)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   project-board-automation:

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -12,6 +12,10 @@ name: 'Project Board Automation'
   pull_request_review_comment:
     types: [created, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Configure the project specific variables
 env:
   ORGANIZATION: vegaprotocol
@@ -26,10 +30,6 @@ env:
   MERGED_COLUMN_NAME: '"Merged"'
   DONE_COLUMN_NAME: '"Done"'
   ITERATION_FIELD_NAME: 'Sprint'   # See project settings (default is `Iteration`)
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   project-board-automation:

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -355,7 +355,7 @@ jobs:
               -f status_value=${{ env.CURRENT_STATUS }} \
               -f iteration_field=$ITERATION_FIELD_ID \
               -f iteration_value=${{ env.CURRENT_ITERATION }}
-   verify-changelog-updated:
+  verify-changelog-updated:
     name: "Verify CHANGELOG Updated"
     needs: project-board-automation
     runs-on: ubuntu-latest

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -7,9 +7,6 @@ name: 'Project Board Automation'
   pull_request_target:
     branches: [develop, main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
-  pull_request:
-    branches: [develop, main]
-    types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request_review:
     types: [submitted, edited]
   pull_request_review_comment:
@@ -358,34 +355,43 @@ jobs:
               -f status_value=${{ env.CURRENT_STATUS }} \
               -f iteration_field=$ITERATION_FIELD_ID \
               -f iteration_value=${{ env.CURRENT_ITERATION }}
-  verify-changelog-updated:
-    name: Verify CHANGELOG Updated
+   verify-changelog-updated:
+    name: "Verify CHANGELOG Updated"
     needs: project-board-automation
     runs-on: ubuntu-latest
     env:
       IS_BOT: ${{needs.project-board-automation.outputs.bot-pr-output}}
     steps:
       - run: env
-      - name: Check bot
+      - name: "Check bot"
         id: check-bot
         if: env.IS_BOT == '1'
-        run: echo "Pull request opened by bot - no changelog required"
-      - name: No changelog required
+        run: echo "pull request opened by bot"
+      - name: "No changelog required"
         id: changelog-excluded
         if: github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'no-changelog') == true
-        run: echo "Changelog requirment excluded"
-      - name: Checkout
+        run: echo "changelog requirment excluded"
+      - name: "Checkout"
         id: checkout
         if: steps.check-bot.outcome == 'skipped' && steps.changelog-excluded.outcome == 'skipped'
         uses: actions/checkout@v3
-      # yamllint enable rule:line-length
-      - name: Check changelog entry
-        id: changelog-check
-        if: steps.checkout.outcome == 'success'
-        uses: Zomzog/changelog-checker@v1.2.0
         with:
-          fileName: CHANGELOG.md
-          noChangelogLabel: "no-changelog"
-          checkNotification: Simple
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - name: "Check changelog entry"
+        shell: pwsh
+        id: check_file_changed
+        if: steps.checkout.outcome == 'success'
+        run: |
+          $diff = git diff --name-only HEAD^ HEAD
+          $SourceDiff = $diff | Where-Object { $_ -match 'CHANGELOG.md' }
+          $HasDiff = $SourceDiff.Length -gt 0
+          Write-Host "::set-output name=changelog_changed::$HasDiff"
+      - name: "Report fail"
+        if: steps.check_file_changed.outputs.changelog_changed != 'True' && steps.check_file_changed.outcome == 'success'
+        uses: actions/github-script@v6.1.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            console.log("Changelog should be updated, or if a small fix the 'no-changelog label used!");
+            core.setFailed("Changelog should be updated, or if a small fix the 'no-changelog label used!");
+        # yamllint enable rule:line-length

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -355,6 +355,7 @@ jobs:
               -f status_value=${{ env.CURRENT_STATUS }} \
               -f iteration_field=$ITERATION_FIELD_ID \
               -f iteration_value=${{ env.CURRENT_ITERATION }}
+  
   verify-changelog-updated:
     name: "Verify CHANGELOG Updated"
     needs: project-board-automation

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -48,8 +48,8 @@ jobs:
       # yamllint disable rule:line-length
       - name: 'Get linked issue id and state'
         id: linked-issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # env:
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api graphql -f query='
             query($pr_url: URI!) {

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -4,6 +4,9 @@
 name: 'Project Board Automation'
 
 "on":
+  pull_request_target:
+    branches: [develop, main]
+    types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request:
     branches: [develop, main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
@@ -26,6 +29,10 @@ env:
   MERGED_COLUMN_NAME: '"Merged"'
   DONE_COLUMN_NAME: '"Done"'
   ITERATION_FIELD_NAME: 'Sprint'   # See project settings (default is `Iteration`)
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   project-board-automation:
@@ -275,7 +282,9 @@ jobs:
           echo 'CURRENT_STATUS='${{ env.IN_REVIEW_COLUMN }} >> $GITHUB_ENV
       - name: 'Set work item for approved column'
         id: approved
-        if: steps.draft-pr.outcome == 'skipped' && env.REVIEW_DECISION == '"APPROVED"'
+        if: |
+          (steps.draft-pr.outcome == 'skipped' && (env.REVIEW_DECISION == '"APPROVED"' ||
+           env.LATEST_REVIEW_STATE == '"APPROVED"'))
         run: |
           echo 'ITEM_ID='${{  env.BOARD_ITEM_ID }} >> $GITHUB_ENV
           echo 'CURRENT_STATUS='${{ env.APPROVED_COLUMN }} >> $GITHUB_ENV

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -4,17 +4,16 @@
 name: 'Project Board Automation'
 
 "on":
-  pull_request_target:
+    pull_request_target:
+    branches: [develop, main]
+    types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
+  pull_request:
     branches: [develop, main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request_review:
     types: [submitted, edited]
   pull_request_review_comment:
     types: [created, edited]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 # Configure the project specific variables
 env:
@@ -355,7 +354,7 @@ jobs:
               -f status_value=${{ env.CURRENT_STATUS }} \
               -f iteration_field=$ITERATION_FIELD_ID \
               -f iteration_value=${{ env.CURRENT_ITERATION }}
-  
+
   verify-changelog-updated:
     name: "Verify CHANGELOG Updated"
     needs: project-board-automation

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -30,7 +30,7 @@ env:
   DONE_COLUMN_NAME: '"Done"'
   ITERATION_FIELD_NAME: 'Sprint'   # See project settings (default is `Iteration`)
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -11,9 +11,9 @@ name: 'Project Board Automation'
     branches: [develop, main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request_review:
-    types: [submitted]
+    types: [submitted, edited]
   pull_request_review_comment:
-    types: [created]
+    types: [created, edited]
 
 # Configure the project specific variables
 env:

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -395,4 +395,3 @@ jobs:
           script: |
             console.log("Changelog should be updated, or if a small fix the 'no-changelog label used!");
             core.setFailed("Changelog should be updated, or if a small fix the 'no-changelog label used!");
-        # yamllint enable rule:line-length


### PR DESCRIPTION
Stop running multiple workflows if multiple trigger conditions are met.

In the current state of the script there are a number of triggers that can start the workflow run. If more than one of these triggers are met it kicks off a workflow run for each, which is not desired.

adding:

```
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

ensures that we cancel any started runs are cancelled and we only have 1 per PR action regardless of how many triggers that action meets.

GitHub actions currents does not have any (accounting to discussions and their docs) functionality to have something like and/or logic on triggers. 

This issue has become more frequent due to:

Using only `pull_request` means the action cannot apply a label to PRs coming from a fork. That's why `pull_request_target` has been added too. This has been added while we transition to using forking flow (if we do). After this it can be left or cleaned up. 

#### Other changes:

- [x] change TOKEN to PAT for first query so links to issue in other repo
- [x] align approval with script in vega repo
- [x] use a script to check the changelog rather that an external action from the market place. I think this is more secure for when we get people contributing via forking flow and from outside the project team.


#### Next steps (for future):

- [ ] keep an eye on https://github.com/community/community/discussions/13015 as I can reduce noise on the cancelled workflows due to concurrency 
- [ ] Move the updates in this action to all other instances for core and devops teams
- [ ] investigate discarding old checks from this workflow in new runs
