### PR TITLE
Configure number of LP orders per side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - [218](https://github.com/vegaprotocol/vegatools/issue/218) - perftest allows multiple LPs and moving of mid price for random orders 
 - [222](https://github.com/vegaprotocol/vegatools/issue/222) - Updated market proposal text with renamed fields
 - [225](https://github.com/vegaprotocol/vegatools/issue/225) - Add option to dump total event counts
+- [227](https://github.com/vegaprotocol/vegatools/issue/227) - Allow configuration of the LP shape
 
 ### 🐛 Fixes
 - [78](https://github.com/vegaprotocol/vegatools/pull/78) - Fix build with missing dependency

--- a/cmd/perftest.go
+++ b/cmd/perftest.go
@@ -26,6 +26,7 @@ func init() {
 	perfTestCmd.Flags().IntVarP(&opts.UserCount, "users", "u", 10, "number of users to send commands with")
 	perfTestCmd.Flags().IntVarP(&opts.MarketCount, "markets", "m", 1, "number of markets to create and use")
 	perfTestCmd.Flags().IntVarP(&opts.Voters, "voters", "v", 3, "number of accounts to assign voting power")
+	perfTestCmd.Flags().IntVarP(&opts.LPOrdersPerSide, "lporders", "l", 3, "number of orders per side in the LP shape")
 	perfTestCmd.Flags().BoolVarP(&opts.MoveMid, "movemidprice", "p", false, "allow the mid price we place orders around to move randomly")
 	perfTestCmd.MarkFlagRequired("address")
 	perfTestCmd.MarkFlagRequired("wallet")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	code.vegaprotocol.io/shared v0.0.0-20220704150014-7c22d12ccb72
-	code.vegaprotocol.io/vega v0.57.1-0.20221007134620-54ab707ac14d
+	code.vegaprotocol.io/vega v0.58.1-0.20221018160916-e5debe36ecb1
 	github.com/cosmos/iavl v0.19.1
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/gdamore/tcell/v2 v2.5.2

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 code.vegaprotocol.io/shared v0.0.0-20220704150014-7c22d12ccb72 h1:BJwmbEbC+ujqLSA1dSyUwDOc4+aRoZcndj/RM210CtE=
 code.vegaprotocol.io/shared v0.0.0-20220704150014-7c22d12ccb72/go.mod h1:P9MfU2GyzI4Vc7OrKx9+qN9JV0bNGFB/aYe0++e7158=
-code.vegaprotocol.io/vega v0.57.1-0.20221007134620-54ab707ac14d h1:9CJJLpF/oldVly33eZi1lQKTGwkVEgNnMx3XxV+yipU=
-code.vegaprotocol.io/vega v0.57.1-0.20221007134620-54ab707ac14d/go.mod h1:FQ3Q23aHsBNIzNL4YyTab2w/cleZQlr/vPfhQym04v4=
+code.vegaprotocol.io/vega v0.58.1-0.20221018160916-e5debe36ecb1 h1:zqPMCOusWpPDPsm8f25fLIxv9cU95nFsIfdvYWTv0KQ=
+code.vegaprotocol.io/vega v0.58.1-0.20221018160916-e5debe36ecb1/go.mod h1:G9A0haG9Qf0GNd6oza8UeDxF9hDVHRwM+1OkUcZnfac=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/perftest/datanode.go
+++ b/perftest/datanode.go
@@ -26,12 +26,12 @@ func (d *dnWrapper) getNetworkParam(param string) (string, error) {
 	}
 
 	for _, value := range response.NetworkParameters {
-		if value.Key == "market.liquidityProvision.shapes.maxSize" {
+		if value.Key == param {
 			return value.Value, nil
 		}
 	}
 	// We didn't find it
-	return "", fmt.Errorf("failed to get network parameter for maximum LP shape size")
+	return "", fmt.Errorf("failed to get network parameter %s", param)
 }
 
 func (d *dnWrapper) getAssets() (map[string]string, error) {

--- a/perftest/datanode.go
+++ b/perftest/datanode.go
@@ -17,6 +17,23 @@ type dnWrapper struct {
 	wallet   walletWrapper
 }
 
+func (d *dnWrapper) getNetworkParam(param string) (string, error) {
+	request := &datanode.NetworkParametersRequest{}
+
+	response, err := d.dataNode.NetworkParameters(context.Background(), request)
+	if err != nil {
+		return "", err
+	}
+
+	for _, value := range response.NetworkParameters {
+		if value.Key == "market.liquidityProvision.shapes.maxSize" {
+			return value.Value, nil
+		}
+	}
+	// We didn't find it
+	return "", fmt.Errorf("failed to get network parameter for maximum LP shape size")
+}
+
 func (d *dnWrapper) getAssets() (map[string]string, error) {
 	request := &datanode.AssetsRequest{}
 

--- a/perftest/datanode.go
+++ b/perftest/datanode.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	datanode "code.vegaprotocol.io/vega/protos/data-node/api/v1"
+	datanode "code.vegaprotocol.io/vega/protos/data-node/api/v2"
 	proto "code.vegaprotocol.io/vega/protos/vega"
 	v1 "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 )
@@ -18,98 +18,99 @@ type dnWrapper struct {
 }
 
 func (d *dnWrapper) getNetworkParam(param string) (string, error) {
-	request := &datanode.NetworkParametersRequest{}
+	request := &datanode.GetNetworkParameterRequest{
+		Key: param,
+	}
 
-	response, err := d.dataNode.NetworkParameters(context.Background(), request)
+	response, err := d.dataNode.GetNetworkParameter(context.Background(), request)
 	if err != nil {
 		return "", err
 	}
 
-	for _, value := range response.NetworkParameters {
-		if value.Key == param {
-			return value.Value, nil
-		}
-	}
-	// We didn't find it
-	return "", fmt.Errorf("failed to get network parameter %s", param)
+	return response.NetworkParameter.Value, nil
 }
 
 func (d *dnWrapper) getAssets() (map[string]string, error) {
-	request := &datanode.AssetsRequest{}
+	request := &datanode.ListAssetsRequest{}
 
-	response, err := d.dataNode.Assets(context.Background(), request)
+	response, err := d.dataNode.ListAssets(context.Background(), request)
 	if err != nil {
 		return nil, err
 	}
 	assets := map[string]string{}
-	for _, asset := range response.Assets {
-		assets[asset.Details.Symbol] = asset.Id
+	for _, asset := range response.GetAssets().GetEdges() {
+		assets[asset.Node.Details.Symbol] = asset.Node.Id
 	}
 	return assets, nil
 }
 
 func (d *dnWrapper) getAssetsPerUser(pubKey, asset string) (int64, error) {
-	request := &datanode.PartyAccountsRequest{
-		PartyId: pubKey,
-		Asset:   asset,
+	request := &datanode.ListAccountsRequest{
+		Filter: &datanode.AccountFilter{
+			AssetId:  asset,
+			PartyIds: []string{pubKey},
+			AccountTypes: []proto.AccountType{
+				proto.AccountType_ACCOUNT_TYPE_GENERAL,
+			},
+		},
 	}
 
-	response, err := d.dataNode.PartyAccounts(context.Background(), request)
+	response, err := d.dataNode.ListAccounts(context.Background(), request)
 	if err != nil {
 		return 0, err
 	}
-	for _, account := range response.Accounts {
-		if account.Type == proto.AccountType_ACCOUNT_TYPE_GENERAL {
-			return strconv.ParseInt(account.Balance, 10, 64)
-		}
+	for _, account := range response.Accounts.Edges {
+		return strconv.ParseInt(account.Account.Balance, 10, 64)
 	}
 	return 0, nil
 }
 
 func (d *dnWrapper) getMarkets() []string {
-	marketsReq := &datanode.MarketsRequest{}
+	marketsReq := &datanode.ListMarketsRequest{}
 
-	response, err := d.dataNode.Markets(context.Background(), marketsReq)
+	response, err := d.dataNode.ListMarkets(context.Background(), marketsReq)
 	if err != nil {
 		log.Println(err)
 		return nil
 	}
 	marketIDs := []string{}
-	for _, market := range response.Markets {
-		if market.State != proto.Market_STATE_REJECTED {
-			marketIDs = append(marketIDs, market.Id)
+	for _, market := range response.Markets.Edges {
+		if market.Node.State != proto.Market_STATE_REJECTED {
+			marketIDs = append(marketIDs, market.Node.Id)
 		}
 	}
 	return marketIDs
 }
 
 func (d *dnWrapper) getPendingProposalID() (string, error) {
-	request := &datanode.GetProposalsRequest{}
+	request := &datanode.ListGovernanceDataRequest{}
 
-	response, err := d.dataNode.GetProposals(context.Background(), request)
+	response, err := d.dataNode.ListGovernanceData(context.Background(), request)
 	if err != nil {
 		log.Println(err)
 	}
 
-	for _, proposal := range response.GetData() {
-		if proposal.Proposal.State == proto.Proposal_STATE_OPEN {
-			return proposal.Proposal.Id, nil
+	for _, proposal := range response.Connection.Edges {
+		if proposal.Node.Proposal.State == proto.Proposal_STATE_OPEN {
+			return proposal.Node.Proposal.Id, nil
 		}
 	}
 	return "", fmt.Errorf("no pending proposals found")
 }
 
 func (d *dnWrapper) waitForMarketEnactment(marketID string, maxWaitSeconds int) error {
-	request := &datanode.GetProposalsRequest{}
+	request := &datanode.ListGovernanceDataRequest{
+		ProposalReference: &marketID,
+	}
 
 	for i := 0; i < maxWaitSeconds; i++ {
-		response, err := d.dataNode.GetProposals(context.Background(), request)
+		response, err := d.dataNode.ListGovernanceData(context.Background(), request)
 		if err != nil {
 			return err
 		}
 
-		for _, proposal := range response.GetData() {
-			if proposal.Proposal.State == proto.Proposal_STATE_ENACTED {
+		for _, proposal := range response.Connection.Edges {
+			if proposal.Node.Proposal.State == proto.Proposal_STATE_ENACTED {
 				return nil
 			}
 		}

--- a/perftest/perftest.go
+++ b/perftest/perftest.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	datanode "code.vegaprotocol.io/vega/protos/data-node/api/v1"
+	datanode "code.vegaprotocol.io/vega/protos/data-node/api/v2"
 	proto "code.vegaprotocol.io/vega/protos/vega"
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 )


### PR DESCRIPTION
Allow the number of orders per side in the liquidity submission to be configurable.

Closes #227 
