### PR TITLE
fix: add-issue-to-project errors

### DIFF
--- a/.github/workflows/add_issue_new_projects.yml
+++ b/.github/workflows/add_issue_new_projects.yml
@@ -1,26 +1,37 @@
 ---
 
-name: Auto Assign Issue to New Project
+name: "Add Issues To Project Board"
 
 "on":
   issues:
     types: [opened]
+env:
+  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  PROJECT_ID: ${{ secrets.CORE_PROJECT_ID }}
+  ISSUE_ID: ${{ github.event.issue.node_id }}
+  USER: ${{ github.actor }}
+  LABEL_ID: "LA_kwDOFFb39c8AAAABG8yt_g"
 
 jobs:
   add_issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Add Issue to New Core Project Board
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
-          PROJECT_ID: ${{ secrets.CORE_PROJECT_ID }}
-          ISSUE_ID: ${{ github.event.issue.node_id }}
+      - name: "Add issue to project board"
         run: |
           gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID -f user=$USER
+
+      - name: "Add repo identify label"
+        run: |
+          gh api graphql -f query='
+            mutation($user:String!, $issue:ID!, $label:[ID!]!) {
+              addLabelsToLabelable(input: {clientMutationId: $user, labelableId: $issue, labelIds: $label}) {
+                clientMutationId
+              }
+            }' -f label=$LABEL_ID -f issue=$ISSUE_ID -f user=$USER

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -228,7 +228,7 @@ jobs:
         run: |
           pr_item_id="$( gh api graphql -f query='
             mutation($user:String!, $project:ID!, $pr:ID!) {
-              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $pr}) {
                 item {
                   id
                 }
@@ -241,7 +241,7 @@ jobs:
         run: |
           pr_item_id="$( gh api graphql -f query='
             mutation($user:String!, $project:ID!, $pr:ID!) {
-              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $pr}) {
                 item {
                   id
                 }

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -1,26 +1,21 @@
 ---
 
 
-name: 'Project Board Automation'
+name: "Project Board Automation"
 
 "on":
   pull_request_target:
-    branches: [develop, main]
-    types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
-  pull_request:
-    branches: [develop, main]
+    branches: [develop, master]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request_review:
-    types: [submitted, edited]
-  pull_request_review_comment:
-    types: [created, edited]
+    types: [submitted]
 
 # Configure the project specific variables
 env:
   ORGANIZATION: vegaprotocol
   PROJECT_NUMBER: 106
   PR_URL: ${{ github.event.pull_request.html_url }}
-  GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
   EXCLUDE_LABEL: 'no-issue'
   IN_PROGRESS_COLUMN_NAME: '"In Progress"'
   REVIEW_REQUIRED_COLUMN_NAME: '"Waiting Review"'
@@ -29,6 +24,7 @@ env:
   MERGED_COLUMN_NAME: '"Merged"'
   DONE_COLUMN_NAME: '"Done"'
   ITERATION_FIELD_NAME: 'Sprint'   # See project settings (default is `Iteration`)
+  USER: ${{ github.actor }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,20 +32,18 @@ concurrency:
 
 jobs:
   project-board-automation:
-    name: 'Linked Issues & Project Board Automation'
+    name: "Linked Issues & Project Board Automation"
     runs-on: ubuntu-latest
     permissions: write-all
-    outputs:
-      bot-pr-output: ${{ steps.bot-pr.outputs.is-bot }}
     steps:
       #######
       ## Gather data, reopen closed issues and ensure work item is on the board
       #######
       # yamllint disable rule:line-length
-      - name: 'Get linked issue id and state'
+      - name: "Get linked issue id and state"
         id: linked-issue
-        # env:
-          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
         run: |
           gh api graphql -f query='
             query($pr_url: URI!) {
@@ -66,15 +60,14 @@ jobs:
             }'  -f pr_url=$PR_URL > data.json
           echo 'LINKED_ISSUE_STATE='$(jq '.data.resource.closingIssuesReferences.nodes[] | .state' data.json) >> $GITHUB_ENV
           echo 'LINKED_ISSUE_ID='$(jq '.data.resource.closingIssuesReferences.nodes[] | .id' data.json) >> $GITHUB_ENV
-      - name: 'Check if PR raised by bot'
+      - name: "Check if PR raised by bot"
         id: bot-pr
         if: |
           ((startsWith(github.head_ref, 'renovate/') == true || startsWith(github.head_ref, 'dependabot/') == true)
            || (github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'))
         run: |
           echo 'BOT_PR=true' >> $GITHUB_ENV
-          echo "::set-output name=is-bot::1"
-      - name: 'Check for linked issue'
+      - name: "Check for linked issue"
         id: linked
         if: |
           env.LINKED_ISSUE_ID != '' &&
@@ -84,7 +77,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             console.log("Linked Issue Found!");
-      - name: 'Check for linked issue exclusion label'
+      - name: "Check for linked issue exclusion label"
         id: exclude-linked
         if: |
           steps.bot-pr.outcome == 'success' || env.LINKED_ISSUE_ID == '' &&
@@ -94,7 +87,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             console.log("Exclusion label added, or a bot-PR no linked issue required!");
-      - name: 'Fail if no linked issue or exclusion label'
+      - name: "Fail if no linked issue or exclusion label"
         id: exclude-linked-error
         if: steps.linked.outcome == 'skipped' && steps.exclude-linked.outcome == 'skipped'
         uses: actions/github-script@v6.1.1
@@ -103,7 +96,7 @@ jobs:
           script: |
             console.log("No linked issue or exclusion label!");
             core.setFailed("Link an issue and rerun, or, add the exclusion label!");
-      - name: 'Fail if linked issue AND exclusion label'
+      - name: "Fail if linked issue AND exclusion label"
         id: linked-and-nochangelog
         if: steps.linked.outcome == 'success' && steps.exclude-linked.outcome == 'success'
         uses: actions/github-script@v6.1.1
@@ -112,35 +105,54 @@ jobs:
           script: |
             console.log("Remove exclusion label, linked issue found!");
             core.setFailed("Remove exclusion label, linked issue found!");
-      - name: 'Get project related data'
+      - name: "Get project related data"
         id: project-data
         run: |
           gh api graphql -f query='
             query($org: String!, $number: Int!) {
               organization(login: $org){
-                projectNext(number: $number) {
+                projectV2(number: $number) {
                   id
                   fields(first:20) {
                     nodes {
-                      id
-                      name
-                      settings
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                      ... on ProjectV2IterationField {
+                        name
+                        id
+                        configuration {
+                          iterations {
+                            id
+                            title
+                          }
+                        }
+                      }
                     }
                   }
                 }
               }
             }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > data.json
-          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' data.json) >> $GITHUB_ENV
-          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' data.json) >> $GITHUB_ENV
-          echo 'IN_PROGRESS_COLUMN='$(jq --arg in_progress ${{ env.IN_PROGRESS_COLUMN_NAME }} '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name==$in_progress) |.id' data.json) >> $GITHUB_ENV
-          echo 'REVIEW_REQUIRED_COLUMN='$(jq --arg review_required ${{ env.REVIEW_REQUIRED_COLUMN_NAME }} '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name==$review_required) |.id' data.json) >> $GITHUB_ENV
-          echo 'IN_REVIEW_COLUMN='$(jq --arg in_review ${{ env.IN_REVIEW_COLUMN_NAME }} '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name==$in_review) |.id' data.json) >> $GITHUB_ENV
-          echo 'APPROVED_COLUMN='$(jq --arg approved ${{ env.APPROVED_COLUMN_NAME }} '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name==$approved) |.id' data.json) >> $GITHUB_ENV
-          echo 'MERGED_COLUMN='$(jq --arg merged ${{ env.MERGED_COLUMN_NAME }} '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name==$merged) |.id' data.json) >> $GITHUB_ENV
-          echo 'DONE_COLUMN='$(jq --arg merged ${{ env.DONE_COLUMN_NAME }} '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name==$merged) |.id' data.json) >> $GITHUB_ENV
-          echo 'ITERATION_FIELD_ID='$(jq --arg iteration_field_name $ITERATION_FIELD_NAME '.data.organization.projectNext.fields.nodes[] | select(.name==$iteration_field_name) | .id' data.json) >> $GITHUB_ENV
-          echo 'CURRENT_ITERATION='$(jq --arg iteration_field_name $ITERATION_FIELD_NAME '.data.organization.projectNext.fields.nodes[] | select(.name==$iteration_field_name) |.settings | fromjson.configuration.iterations[0] | .id' data.json) >> $GITHUB_ENV
-      - name: 'Get PR state, review decision and author'
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' data.json) >> $GITHUB_ENV
+          echo 'IN_PROGRESS_COLUMN='$(jq --arg in_progress ${{ env.IN_PROGRESS_COLUMN_NAME }} '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name==$in_progress) | .id' data.json) >> $GITHUB_ENV
+          echo 'REVIEW_REQUIRED_COLUMN='$(jq --arg review_required ${{ env.REVIEW_REQUIRED_COLUMN_NAME }} '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name==$review_required) | .id' data.json) >> $GITHUB_ENV
+          echo 'IN_REVIEW_COLUMN='$(jq --arg in_review ${{ env.IN_REVIEW_COLUMN_NAME }} '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name==$in_review) | .id' data.json) >> $GITHUB_ENV
+          echo 'APPROVED_COLUMN='$(jq --arg approved ${{ env.APPROVED_COLUMN_NAME }} '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name==$approved) | .id' data.json) >> $GITHUB_ENV
+          echo 'MERGED_COLUMN='$(jq --arg merged ${{ env.MERGED_COLUMN_NAME }} '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name==$merged) | .id' data.json) >> $GITHUB_ENV
+          echo 'DONE_COLUMN='$(jq --arg done ${{ env.DONE_COLUMN_NAME }} '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name==$done) | .id' data.json) >> $GITHUB_ENV
+          echo 'ITERATION_FIELD_ID='$(jq --arg iteration_field_name $ITERATION_FIELD_NAME '.data.organization.projectV2.fields.nodes[] | select(.name==$iteration_field_name) | .id' data.json) >> $GITHUB_ENV
+          echo 'CURRENT_ITERATION='$(jq --arg iteration_field_name $ITERATION_FIELD_NAME '.data.organization.projectV2.fields.nodes[] | select(.name==$iteration_field_name) | .configuration.iterations[0] | .id' data.json) >> $GITHUB_ENV
+      - name: "Get PR state, review decision and author"
         id: pr-status
         run: |
           gh api graphql -f query='
@@ -169,16 +181,14 @@ jobs:
                 }
               }
             }'  -f pr_url=$PR_URL > data.json
-          echo 'REVIEWS_COUNT='$(jq '[.data.resource.reviewThreads.edges[] | .node | select(.isResolved != null) | length] | add' data.json) >> $GITHUB_ENV
-          echo 'OPEN_REVIEW_COUNT='$(jq '[.data.resource.reviewThreads.edges[] | .node | select(.isResolved == false) | length] | add' data.json) >> $GITHUB_ENV
           echo 'REVIEW_DECISION='$(jq '.data.resource | .reviewDecision' data.json) >> $GITHUB_ENV
-          echo 'NUM_REVIEWS='$(jq '.data.resource.reviews | .totalCount' data.json) >> $GITHUB_ENV
+          echo 'NUM_REVIEWS='$(jq '.data.resource.reviews.nodes | length' data.json) >> $GITHUB_ENV
           echo 'LATEST_REVIEW_STATE='$(jq '.data.resource.reviews.nodes[] | .state' data.json) >> $GITHUB_ENV
           echo 'IS_PR_DRAFT='$(jq '.data.resource | .isDraft' data.json) >> $GITHUB_ENV
           echo 'PR_STATE='$(jq '.data.resource | .state' data.json) >> $GITHUB_ENV
           echo 'PR_ID='$(jq '.data.resource | .id' data.json) >> $GITHUB_ENV
           echo 'AUTHOR_NAME='$(jq '.data.resource.author | .login' data.json) >> $GITHUB_ENV
-      - name: 'Get PR author id'
+      - name: "Get PR author id"
         id: pr-author
         if: steps.pr-status.outcome == 'success'
         run: |
@@ -195,50 +205,50 @@ jobs:
               }
             }'  -f author_name=$AUTHOR_NAME > data.json
           echo 'AUTHOR_ID='$(jq '.data.search.edges[] | .node | .id' data.json) >> $GITHUB_ENV
-      - name: 'Add linked issue to the project'
+      - name: "Add linked issue to the project"
         id: issue-to-project
         if: |
           env.LINKED_ISSUE_ID != '' &&
            contains(github.event.pull_request.labels.*.name, env.EXCLUDE_LABEL) != true
         run: |
           issue_item_id="$( gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$LINKED_ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+            }' -f project=$PROJECT_ID -f issue=$LINKED_ISSUE_ID -f user=$USER --jq '.data.addProjectV2ItemById.item.id')"
           echo 'BOARD_ITEM_ID='$issue_item_id >> $GITHUB_ENV
-      - name: 'Add exclusion labeled PR to the project'
+      - name: "Add exclusion labeled PR to the project"
         id: pr-to-project
         if: |
           steps.issue-to-project.outcome == 'skipped' &&
            contains(github.event.pull_request.labels.*.name, env.EXCLUDE_LABEL) == true
         run: |
           pr_item_id="$( gh api graphql -f query='
-            mutation($project:ID!, $pr:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $pr:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+            }' -f project=$PROJECT_ID -f pr=$PR_ID  -f user=$USER --jq '.data.addProjectV2ItemById.item.id')"
           echo 'BOARD_ITEM_ID='$pr_item_id >> $GITHUB_ENV
-      - name: 'Add BOT PR to the project'
+      - name: "Add BOT PR to the project"
         id: bot-pr-to-project
         if: steps.bot-pr.outcome == 'success'
         run: |
           pr_item_id="$( gh api graphql -f query='
-            mutation($project:ID!, $pr:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $pr:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+            }' -f project=$PROJECT_ID -f pr=$PR_ID  -f user=$USER --jq '.data.addProjectV2ItemById.item.id')"
           echo 'BOARD_ITEM_ID='$pr_item_id >> $GITHUB_ENV
-      - name: 'Reopen if the linked issue closed'
+      - name: "Reopen if the linked issue closed"
         id: reopen-issue
         if: steps.issue-to-project.outcome == 'success' && env.LINKED_ISSUE_STATE == '"CLOSED"' && env.PR_STATE != '"MERGED"'
         run: |
@@ -256,45 +266,45 @@ jobs:
       #######
       ## Set the variables ready to update work item on project board
       #######
-      - name: 'Set draft work item for progress column'
+      - name: "Set draft work item for progress column"
         id: draft-pr
         if: github.event.pull_request.draft == 'true' || env.IS_PR_DRAFT == 'true'
         run: |
           echo 'ITEM_ID='${{  env.BOARD_ITEM_ID }} >> $GITHUB_ENV
           echo 'CURRENT_ITERATION='$CURRENT_ITERATION >> $GITHUB_ENV
           echo 'CURRENT_STATUS='${{ env.IN_PROGRESS_COLUMN }} >> $GITHUB_ENV
-      - name: 'Set work item for review required column'
+      - name: "Set work item for review required column"
         id: review-required
         if: |
           github.event.action == 'ready_for_review' ||
-           env.IS_PR_DRAFT != 'true' && env.REVIEWS_COUNT == 'null'
+           env.IS_PR_DRAFT != 'true' && env.NUM_REVIEWS == 0 && env.REVIEW_DECISION == '"REVIEW_REQUIRED"'
         run: |
           echo 'ITEM_ID='${{  env.BOARD_ITEM_ID }} >> $GITHUB_ENV
           echo 'CURRENT_STATUS='${{ env.REVIEW_REQUIRED_COLUMN }} >> $GITHUB_ENV
-      - name: 'Set work item for in review column'
+      - name: "Set work item for in review column"
         id: changes-requested
         if: |
-          (steps.draft-pr.outcome == 'skipped' && env.REVIEWS_COUNT != 'null' &&
+          (steps.draft-pr.outcome == 'skipped' && env.NUM_REVIEWS > 0 &&
            (env.REVIEW_DECISION == '"CHANGES_REQUESTED"' || env.LATEST_REVIEW_STATE == '"COMMENTED"'
            || env.LATEST_REVIEW_STATE == '"DISMISSED"'))
         run: |
           echo 'ITEM_ID='${{  env.BOARD_ITEM_ID }} >> $GITHUB_ENV
           echo 'CURRENT_STATUS='${{ env.IN_REVIEW_COLUMN }} >> $GITHUB_ENV
-      - name: 'Set work item for approved column'
+      - name: "Set work item for approved column"
         id: approved
         if: |
-          (steps.draft-pr.outcome == 'skipped' && (env.REVIEW_DECISION == '"APPROVED"' ||
-           env.LATEST_REVIEW_STATE == '"APPROVED"'))
+          (steps.draft-pr.outcome == 'skipped' && (env.REVIEW_DECISION == '"APPROVED"'
+           || env.LATEST_REVIEW_STATE == '"APPROVED"'))
         run: |
           echo 'ITEM_ID='${{  env.BOARD_ITEM_ID }} >> $GITHUB_ENV
           echo 'CURRENT_STATUS='${{ env.APPROVED_COLUMN }} >> $GITHUB_ENV
-      - name: 'Set work item for merged column'
+      - name: "Set work item for merged column"
         id: merged
         if: env.PR_STATE == '"MERGED"' || github.event.pull_request.merged == true
         run: |
           echo 'ITEM_ID='${{  env.BOARD_ITEM_ID }} >> $GITHUB_ENV
           echo 'CURRENT_STATUS='${{ env.MERGED_COLUMN }} >> $GITHUB_ENV
-      - name: 'Close linked issue when PR mergd'
+      - name: "Close linked issue when PR merged"
         id: close-issue
         if: steps.merged.outcome == 'success' && steps.linked.outcome == 'success'
         run: |
@@ -306,13 +316,13 @@ jobs:
                 }
               }
             }' -f clientMutationId=$AUTHOR_ID -f issueId=$LINKED_ISSUE_ID
-      - name: 'Set closed PR for done column'
+      - name: "Set closed PR for done column"
         id: closed-pr
         if: steps.exclude-linked.outcome == 'success' && github.event.pull_request.closed == true
         run: |
           echo 'ITEM_ID='${{  env.BOARD_ITEM_ID }} >> $GITHUB_ENV
           echo 'CURRENT_STATUS='${{ env.DONE_COLUMN }} >> $GITHUB_ENV
-      - name: 'Set closed PR issue to in progress column'
+      - name: "Set closed PR issue to in progress column"
         id: closed-pr-with-issue
         if: steps.linked.outcome == 'success' && github.event.pull_request.merged == true && env.PR_STATE != '"MERGED"'
         run: |
@@ -332,23 +342,27 @@ jobs:
               $iteration_field: ID!
               $iteration_value: String!
             ) {
-              set_status: updateProjectNextItemField(input: {
+              set_status: updateProjectV2ItemFieldValue(input: {
                 projectId: $project
                 itemId: $item
                 fieldId: $status_field
-                value: $status_value
+                value: {
+                  singleSelectOptionId: $status_value
+                  }
               }) {
-                projectNextItem {
+                projectV2Item {
                   id
                   }
               }
-              set_iteration: updateProjectNextItemField(input: {
+              set_iteration: updateProjectV2ItemFieldValue(input: {
                 projectId: $project
                 itemId: $item
                 fieldId: $iteration_field
-                value: $iteration_value
+                value: {
+                  iterationId: $iteration_value
+                  }
               }) {
-                projectNextItem {
+                projectV2Item {
                   id
                 }
               }
@@ -358,43 +372,24 @@ jobs:
               -f status_value=${{ env.CURRENT_STATUS }} \
               -f iteration_field=$ITERATION_FIELD_ID \
               -f iteration_value=${{ env.CURRENT_ITERATION }}
-
   verify-changelog-updated:
     name: "Verify CHANGELOG Updated"
     needs: project-board-automation
     runs-on: ubuntu-latest
-    env:
-      IS_BOT: ${{needs.project-board-automation.outputs.bot-pr-output}}
+    if: |
+      github.event.pull_request.draft != true
+       && contains(github.event.pull_request.labels.*.name, 'no-changelog') != true
     steps:
-      - run: env
-      - name: "Check bot"
-        id: check-bot
-        if: env.IS_BOT == '1'
-        run: echo "pull request opened by bot"
-      - name: "No changelog required"
-        id: changelog-excluded
-        if: github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'no-changelog') == true
-        run: echo "changelog requirment excluded"
       - name: "Checkout"
         id: checkout
-        if: steps.check-bot.outcome == 'skipped' && steps.changelog-excluded.outcome == 'skipped'
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: "Check changelog entry"
-        shell: pwsh
-        id: check_file_changed
-        if: steps.checkout.outcome == 'success'
-        run: |
-          $diff = git diff --name-only HEAD^ HEAD
-          $SourceDiff = $diff | Where-Object { $_ -match 'CHANGELOG.md' }
-          $HasDiff = $SourceDiff.Length -gt 0
-          Write-Host "::set-output name=changelog_changed::$HasDiff"
-      - name: "Report fail"
-        if: steps.check_file_changed.outputs.changelog_changed != 'True' && steps.check_file_changed.outcome == 'success'
-        uses: actions/github-script@v6.1.0
+        id: check-changelog
+        uses: Zomzog/changelog-checker@v1.2.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            console.log("Changelog should be updated, or if a small fix the 'no-changelog label used!");
-            core.setFailed("Changelog should be updated, or if a small fix the 'no-changelog label used!");
+          fileName: CHANGELOG.md
+          noChangelogLabel: "no-changelog"
+          checkNotification: Simple
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # yamllint enable rule:line-length


### PR DESCRIPTION
The Add Issues To Project Board github action is failing due to the old API being deprecated

gh: The ProjectNext API is deprecated in favour of the more capable ProjectV2 API. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. {"data":{"addProjectNextItem":null},"errors":[{"type":"NOT_FOUND","path":["addProjectNextItem"],"locations":[{"line":3,"column":5}],"message":"The ProjectNext API is deprecated in favour of the more capable ProjectV2 API. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement."}]}
Error: Process completed with exit code 1.