### PR TITLE
fix: diff discrepancies fixed

### DIFF
--- a/difftool/diff/core_snapshot.go
+++ b/difftool/diff/core_snapshot.go
@@ -202,7 +202,7 @@ func (s *snap) getOrders() []*vega.Order {
 		o.ExpiresAt = (o.ExpiresAt / 1000) * 1000
 		o.UpdatedAt = (o.UpdatedAt / 1000) * 1000
 		price, _ := decimal.NewFromString(o.Price)
-		o.Price = price.Div(dpFactors[o.MarketId]).String()
+		o.Price = price.Div(dpFactors[o.MarketId]).Truncate(0).String()
 	}
 
 	return orders

--- a/difftool/diff/datanode_client.go
+++ b/difftool/diff/datanode_client.go
@@ -272,7 +272,9 @@ func (dnc *dataNodeClient) listAssets() ([]*vega.Asset, error) {
 	}
 	assets := make([]*vega.Asset, 0, len(assetResp.Assets.Edges))
 	for _, a := range assetResp.Assets.Edges {
-		assets = append(assets, a.Node)
+		if a.Node.Status != vega.Asset_STATUS_REJECTED {
+			assets = append(assets, a.Node)
+		}
 	}
 	return assets, nil
 }
@@ -435,7 +437,10 @@ func (dnc *dataNodeClient) getStake() ([]*v1.StakeLinking, error) {
 			return stake, err
 		}
 		for _, sle := range resp.StakeLinkings.Edges {
-			stake = append(stake, sle.Node)
+			// ignore 0 amounts
+			if sle.Node.Amount != "0" {
+				stake = append(stake, sle.Node)
+			}
 		}
 	}
 	return stake, nil

--- a/difftool/diff/diff_report.go
+++ b/difftool/diff/diff_report.go
@@ -72,10 +72,6 @@ func diffAccountBalances(coreSnapshot *Result, dn *Result) Status {
 	}
 	datanode = filteredDN
 
-	if len(core) != len(datanode) {
-		return getSizeMismatchStatus("accounts", core, datanode)
-	}
-
 	sort.Slice(core, func(i, j int) bool {
 		return core[i].Owner+core[i].MarketId+core[i].Asset+core[i].Type.String() < core[j].Owner+core[j].MarketId+core[j].Asset+core[j].Type.String()
 	})


### PR DESCRIPTION
issues fixed:
1. order price in core truncated correctly
2. ignore rejected asset in comparison as core won't have them
3. ignore stake linking in datanode with 0 amount as core won't have them (we probably shouldn't emit the event in the first place but anyways)
4. don't compare sizes in account balances as datanode will have margin accounts with balance 0 and core won't have them for distressed parties