### PR TITLE
Add final report to eventrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - [254](https://github.com/vegaprotocol/vegatools/issues/254) - Updated auth to use VWT header value
 - [256](https://github.com/vegaprotocol/vegatools/issues/256) - Fix batch orders 
 - [260](https://github.com/vegaprotocol/vegatools/issues/260) - Better handling of staking assets in perftool 
+- [264](https://github.com/vegaprotocol/vegatools/issues/264) - Eventrate tool can now output a simple report and then exit for use in scripts 
 
 ### 🐛 Fixes
 - [78](https://github.com/vegaprotocol/vegatools/pull/78) - Fix build with missing dependency

--- a/cmd/eventrate.go
+++ b/cmd/eventrate.go
@@ -21,6 +21,7 @@ func init() {
 	eventRateCmd.Flags().IntVarP(&eventRateOpts.Buckets, "buckets", "b", 10, "number of historic buckets")
 	eventRateCmd.Flags().IntVarP(&eventRateOpts.SecondsPerBucket, "secondsperbucket", "s", 1, "number of seconds to record each bucket")
 	eventRateCmd.Flags().IntVarP(&eventRateOpts.EventCountDump, "eventcountdump", "e", 0, "dump total event count every x seconds")
+	eventRateCmd.Flags().IntVarP(&eventRateOpts.FinalReportRowCount, "finalreport", "f", 0, "generate a report after x number of calculations")
 	eventRateCmd.Flags().BoolVarP(&eventRateOpts.ReportStyle, "reportstyle", "r", false, "print output on a new line")
 	eventRateCmd.MarkFlagRequired("address")
 }


### PR DESCRIPTION
Add an option to generate a single line output of the average event rate and message size and then exit.

Closes #264 