### PR TITLE
Check for overflowing price levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - [268](https://github.com/vegaprotocol/vegatools/issues/268) - Streamlatency tool to measure latency difference between two different event streams 
 - [270](https://github.com/vegaprotocol/vegatools/issues/270) - signingrate tool to benchmark a server to see at what rate they can sign transactions
 - [281](https://github.com/vegaprotocol/vegatools/issues/281) - add a toggle to perftest to enable/disable lp users from creating initial orders 
+- [288](https://github.com/vegaprotocol/vegatools/issues/288) - stop processing per testing if the number of price levels is greater than the mid price
 
 
 ### 🐛 Fixes

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	code.vegaprotocol.io/shared v0.0.0-20221010085458-55c50711135f
-	code.vegaprotocol.io/vega v0.70.1-0.20230419150238-cdfb016b9196
+	code.vegaprotocol.io/vega v0.71.6
 	github.com/cosmos/iavl v0.19.4
 	github.com/ethereum/go-ethereum v1.11.2
 	github.com/gdamore/tcell/v2 v2.5.2

--- a/go.sum
+++ b/go.sum
@@ -61,7 +61,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 code.vegaprotocol.io/shared v0.0.0-20221010085458-55c50711135f h1:ivaWSXN7XKESShqYw/QFuT6b2mvThWPQLO7lW5sadHs=
 code.vegaprotocol.io/shared v0.0.0-20221010085458-55c50711135f/go.mod h1:XzX67GsyOHzvytMr0QOHX4CCTdCZDYKUUi88rx40Nt0=
-code.vegaprotocol.io/vega v0.71.6 h1:ymUzr5QPIP/g4LftFb1XhVPUEzc8Z0wyihuc2FiKosc=
+code.vegaprotocol.io/vega v0.71.6 h1:d5+ZOPAq5hpuih+E/XsBTLDoKb1h9ECp0Gsx5vCPdBc=
 code.vegaprotocol.io/vega v0.71.6/go.mod h1:2/tnFImHhnoel/PeX0n5uiNSqdXyHLcLKXRhLENzPSw=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 code.vegaprotocol.io/shared v0.0.0-20221010085458-55c50711135f h1:ivaWSXN7XKESShqYw/QFuT6b2mvThWPQLO7lW5sadHs=
 code.vegaprotocol.io/shared v0.0.0-20221010085458-55c50711135f/go.mod h1:XzX67GsyOHzvytMr0QOHX4CCTdCZDYKUUi88rx40Nt0=
-code.vegaprotocol.io/vega v0.70.1-0.20230419150238-cdfb016b9196 h1:HMY/9+XUr8hvq4YI/HkVxuv3ohEbNW6GwEAc22fk13A=
-code.vegaprotocol.io/vega v0.70.1-0.20230419150238-cdfb016b9196/go.mod h1:2/tnFImHhnoel/PeX0n5uiNSqdXyHLcLKXRhLENzPSw=
+code.vegaprotocol.io/vega v0.71.6 h1:ymUzr5QPIP/g4LftFb1XhVPUEzc8Z0wyihuc2FiKosc=
+code.vegaprotocol.io/vega v0.71.6/go.mod h1:2/tnFImHhnoel/PeX0n5uiNSqdXyHLcLKXRhLENzPSw=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Antonboom/errname v0.1.7/go.mod h1:g0ONh16msHIPgJSGsecu1G/dcF2hlYR/0SddnIAGavU=


### PR DESCRIPTION
In the perftest tool, if we try to add price levels to a market but we are adding more levels than the starting mid price, it will overflow. Added a check to stop this happening.

Closes #288 
