### PR TITLE
read pending stake-linkings from verifier snapshot chunk

### DIFF
--- a/cmd/difftool.go
+++ b/cmd/difftool.go
@@ -30,8 +30,8 @@ func init() {
 	diffToolCmd.Flags().StringVarP(&diffToolOpts.datanode, "datanode", "d", "", "datanode url")
 	diffToolCmd.MarkFlagRequired("snap-db-path")
 	diffToolCmd.MarkFlagRequired("datanode")
-
 }
+
 func runDiffToolCmd(cmd *cobra.Command, args []string) error {
 	temp := os.TempDir()
 	if !strings.HasSuffix(temp, string(os.PathSeparator)) {
@@ -40,7 +40,7 @@ func runDiffToolCmd(cmd *cobra.Command, args []string) error {
 	println(temp)
 	snapshotPath := temp + "snapshot.dat"
 
-	err := snapshotdb.Run(diffToolOpts.snapshotDatabasePath, false, snapshotPath, snapshotDBOpts.heightToOutput, "proto")
+	err := snapshotdb.Run(diffToolOpts.snapshotDatabasePath, false, snapshotPath, diffToolOpts.heightToOutput, "proto")
 	defer os.Remove(snapshotPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Pending stake-linkings are not stored in the same snapshot chunk as the finalized versions, so we need to hunt them out separately.

relates to: https://github.com/vegaprotocol/vega/issues/8672

full system test run:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/23734/pipeline