### PR TITLE
chore: update difftool to read from new LP V2 snapshot payload

### DIFF
--- a/difftool/diff/core_snapshot.go
+++ b/difftool/diff/core_snapshot.go
@@ -107,6 +107,8 @@ func (s *snap) getLps() []*vega.LiquidityProvision {
 		switch c.Data.(type) {
 		case *snapshot.Payload_LiquidityProvisions:
 			lps = append(lps, c.GetLiquidityProvisions().LiquidityProvisions...)
+		case *snapshot.Payload_LiquidityV2Provisions:
+			lps = append(lps, c.GetLiquidityV2Provisions().LiquidityProvisions...)
 		default:
 			continue
 		}


### PR DESCRIPTION
closes #308 

system test now working:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/26437/pipeline