### PR TITLE
Skip initialisation

### DIFF
--- a/cmd/perftest.go
+++ b/cmd/perftest.go
@@ -38,6 +38,7 @@ func init() {
 	perfTestCmd.Flags().BoolVarP(&opts.MoveMid, "movemidprice", "M", false, "allow the mid price we place orders around to move randomly")
 	perfTestCmd.Flags().BoolVarP(&opts.FillPriceLevels, "fillpricelevel", "F", false, "place an order at every available price level")
 	perfTestCmd.Flags().BoolVarP(&opts.InitialiseOnly, "initialiseonly", "i", false, "initialise everything and then exit")
+	perfTestCmd.Flags().BoolVarP(&opts.DoNotInitialise, "donotinitialise", "I", false, "skip the initialise steps")
 	perfTestCmd.Flags().BoolVarP(&opts.UseLPsForOrders, "uselpsfororders", "U", true, "allow lp users to place orders during setup")
 	perfTestCmd.MarkFlagRequired("address")
 	perfTestCmd.MarkFlagRequired("wallet")

--- a/perftest/perftest.go
+++ b/perftest/perftest.go
@@ -42,6 +42,7 @@ type Opts struct {
 	StartingMidPrice  int64
 	FillPriceLevels   bool
 	InitialiseOnly    bool
+	DoNotInitialise   bool
 	UseLPsForOrders   bool
 }
 
@@ -106,6 +107,10 @@ func (p *perfLoadTesting) LoadUsers(opts Opts) error {
 }
 
 func (p *perfLoadTesting) depositTokens(assets map[string]string, opts Opts) error {
+	if opts.DoNotInitialise {
+		return nil
+	}
+
 	if len(opts.GanacheURL) > 0 {
 		for index, user := range p.users {
 			if index >= opts.Voters {
@@ -240,6 +245,19 @@ func (p *perfLoadTesting) checkNetworkLimits(opts Opts) error {
 
 func (p *perfLoadTesting) proposeAndEnactMarket(opts Opts) ([]string, error) {
 	markets := p.dataNode.getMarkets()
+
+	if opts.DoNotInitialise {
+		marketIds := []string{}
+		if len(markets) >= opts.MarketCount {
+			for _, market := range markets {
+				marketIds = append(marketIds, market.Id)
+			}
+			return marketIds, nil
+		} else {
+			return nil, fmt.Errorf("failed to get open market")
+		}
+	}
+
 	if len(markets) == 0 {
 		for i := 0; i < opts.MarketCount; i++ {
 			err := p.wallet.NewMarket(i, p.users[0])
@@ -310,6 +328,9 @@ func (p *perfLoadTesting) proposeAndEnactMarket(opts Opts) ([]string, error) {
 }
 
 func (p *perfLoadTesting) seedPeggedOrders(marketIDs []string, opts Opts) error {
+	if opts.DoNotInitialise {
+		return nil
+	}
 	// Loop through every market
 	for _, marketID := range marketIDs {
 		for i := 0; i < opts.PeggedOrders; i++ {
@@ -360,6 +381,9 @@ func (p *perfLoadTesting) seedPeggedOrders(marketIDs []string, opts Opts) error 
 }
 
 func (p *perfLoadTesting) seedPriceLevels(marketIDs []string, opts Opts) error {
+	if opts.DoNotInitialise {
+		return nil
+	}
 	for _, marketID := range marketIDs {
 		// Buys first
 		for i := opts.StartingMidPrice - 1; i > opts.StartingMidPrice-int64(opts.PriceLevels); i-- {
@@ -409,6 +433,9 @@ func (p *perfLoadTesting) seedPriceLevels(marketIDs []string, opts Opts) error {
 }
 
 func (p *perfLoadTesting) seedStopOrders(marketIDs []string, opts Opts) error {
+	if opts.DoNotInitialise {
+		return nil
+	}
 	// We need to go through all markets and all users
 	for _, marketID := range marketIDs {
 		order := &commandspb.OrderSubmission{
@@ -856,13 +883,14 @@ func Run(opts Opts) error {
 
 	// If we are only initialising, stop now and return
 	if opts.InitialiseOnly {
+		fmt.Print("Depositing tokens and assets...")
 		// Make one more check that assets are topped up
 		err = plt.depositTokens(assets, opts)
 		if err != nil {
 			fmt.Println("FAILED")
 			return err
 		}
-
+		fmt.Println("Complete")
 		fmt.Println("Initialisation complete")
 		return nil
 	}

--- a/perftest/perftest.go
+++ b/perftest/perftest.go
@@ -253,9 +253,8 @@ func (p *perfLoadTesting) proposeAndEnactMarket(opts Opts) ([]string, error) {
 				marketIds = append(marketIds, market.Id)
 			}
 			return marketIds, nil
-		} else {
-			return nil, fmt.Errorf("failed to get open market")
 		}
+		return nil, fmt.Errorf("failed to get open market")
 	}
 
 	if len(markets) == 0 {


### PR DESCRIPTION
Allow the perftest tool to move straight to sending orders without checking that the users and markets are created correctly.

Closes #316 